### PR TITLE
Update the oc command to use daemonset for modifying spod

### DIFF
--- a/modules/spo-memory-optimzation.adoc
+++ b/modules/spo-memory-optimzation.adoc
@@ -21,7 +21,7 @@ SPO memory optimization is not enabled by default.
 +
 [source,terminal]
 ----
-$ oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableMemoryOptimization":true}}'
+$ oc -n openshift-security-profiles patch daemonset spod --type=merge -p '{"spec":{"enableMemoryOptimization":true}}'
 ----
 
 . To record a security profile for a pod, the pod must be labeled with `spo.x-k8s.io/enable-recording: "true"`:


### PR DESCRIPTION
When modifying the resource limits for spod daemonsets the command was
using spod as a resource, which doesn't exist. We actually want to
modify the daemonset.
