### PR TITLE
CMP-2582: Update CO install documentation to include ROSA support

### DIFF
--- a/modules/compliance-operator-rosa-installation.adoc
+++ b/modules/compliance-operator-rosa-installation.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/co-management/compliance-operator-installation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-compliance-operator-cli_{context}"]
+= Installing the Compliance Operator on ROSA
+
+As of the Compliance Operator 1.5.0 release, the operator is tested against Red Hat
+OpenShift Service on AWS (ROSA) using hosted control plane topologies (HCP).
+
+ROSA HCP clusters restrict access to the control plane, which is managed by Red
+Hat. By default, the Compliance Operator will schedule to nodes within the
+`master` node pool, which isn't available in ROSA HCP installations. This
+requires you to configure the `Subscription` object in a way that allows the
+operator to schedule on available node pools. This step is necessary for a
+successful installation on ROSA HCP clusters.
+
+.Prerequisites
+
+* You must have `admin` privileges.
+
+.Procedure
+
+. Define a `Namespace` object:
++
+.Example `namespace-object.yaml`
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged <1>
+  name: openshift-compliance
+----
+<1> in {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
+
+. Create the `Namespace` object:
++
+[source,terminal]
+----
+$ oc create -f namespace-object.yaml
+----
+
+. Define an `OperatorGroup` object:
++
+.Example `operator-group-object.yaml`
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance
+----
+
+. Create the `OperatorGroup` object:
++
+[source,terminal]
+----
+$ oc create -f operator-group-object.yaml
+----
+
+. Define a `Subscription` object:
++
+.Example `subscription-object.yaml`
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: "stable"
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: "" <1>
+----
+<1> update the operator deployment to deploy on `worker` nodes.
+
+. Create the `Subscription` object:
++
+[source,terminal]
+----
+$ oc create -f subscription-object.yaml
+----
+
+[NOTE]
+====
+If you are setting the global scheduler feature and enable `defaultNodeSelector`, you must create the namespace manually and update the annotations of the `openshift-compliance` namespace, or the namespace where the Compliance Operator was installed, with `openshift.io/node-selector: “”`. This removes the default node selector and prevents deployment failures.
+====
+
+.Verification
+
+. Verify the installation succeeded by inspecting the CSV file:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-compliance
+----
+
+. Verify that the Compliance Operator is up and running:
++
+[source,terminal]
+----
+$ oc get deploy -n openshift-compliance
+----

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -10,7 +10,7 @@ Before you can use the Compliance Operator, you must ensure it is deployed in th
 
 [IMPORTANT]
 ====
-The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Microsoft Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated and Microsoft Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
 
 include::modules/compliance-operator-console-installation.adoc[leveloffset=+1]
@@ -23,6 +23,8 @@ You can create a custom SCC for the Compliance Operator scanner pod service acco
 ====
 
 include::modules/compliance-operator-cli-installation.adoc[leveloffset=+1]
+
+include::modules/compliance-operator-rosa-installation.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The next Compliance Operator release (1.5.0) will include ROSA HCP
support.

This commit updates the installation documentation show users how they
can install the operator if they're running ROSA HCP clusters.
