### PR TITLE
CMP-2583: Update CO supported profiles to include supported platforms

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -18,6 +18,7 @@ The Compliance Operator provides the following compliance profiles:
 |Compliance Operator version
 |Industry compliance benchmark
 |Supported architectures
+|Supported platforms
 
 |rhcos4-stig
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -25,6 +26,7 @@ The Compliance Operator provides the following compliance profiles:
 |1.3.0+
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-stig-node
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -32,6 +34,7 @@ The Compliance Operator provides the following compliance profiles:
 |1.3.0+
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-stig
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -57,6 +60,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-cis
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.5.0
@@ -75,6 +79,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
@@ -98,6 +103,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS
@@ -105,6 +111,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-moderate-node
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
@@ -114,6 +121,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
@@ -128,6 +136,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/USRelStand.aspx[NERC CIP Standards]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for Red Hat Enterprise Linux CoreOS
@@ -135,6 +144,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/USRelStand.aspx[NERC CIP Standards]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-pci-dss
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
@@ -151,6 +161,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-high
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Platform level
@@ -165,6 +176,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-high
 |NIST 800-53 High-Impact Baseline for Red Hat Enterprise Linux CoreOS
@@ -172,6 +184,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 |===
 [.small]
 1. To locate the CIS {product-title} v4 Benchmark, go to  link:https://www.cisecurity.org/benchmark/kubernetes[CIS Benchmarks] and click *Download Latest CIS Benchmark*, where you can then register to download the benchmark.

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -18,7 +18,7 @@ authorized auditor to achieve compliance with a standard.
 
 [IMPORTANT]
 ====
-The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+The Compliance Operator might report incorrect results on some managed platforms, such as OpenShift Dedicated and Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
 
 include::modules/compliance-supported-profiles.adoc[leveloffset=+1]


### PR DESCRIPTION
With Compliance Operator 1.5.0, users can deploy the Compliance Operator
on ROSA HCP. Let's update the documentation to advertise that
functionality for profiles that are tested on ROSA HCP.
